### PR TITLE
Potential fix for code scanning alert no. 16: Reflected cross-site scripting

### DIFF
--- a/diff/avo/main.go
+++ b/diff/avo/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"log"
 	"net/http"
 	"strings"
@@ -70,7 +71,8 @@ func handleOne(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		if _, err := w.Write(element); err != nil {
+		escapedElement := html.EscapeString(string(element))
+		if _, err := w.Write([]byte(escapedElement)); err != nil {
 			log.Print(err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return


### PR DESCRIPTION
Potential fix for [https://github.com/OlexandrPodustov/personalPerformance/security/code-scanning/16](https://github.com/OlexandrPodustov/personalPerformance/security/code-scanning/16)

To fix this safely without changing core behavior, ensure untrusted stored content is escaped before being written to the HTTP response in the GET path.

Best concrete fix in `diff/avo/main.go`:
- Add import: `html`.
- In `handleOne`, `http.MethodGet` branch, escape `element` before writing:
  - Convert bytes to string.
  - Apply `html.EscapeString(...)`.
  - Write escaped bytes to response.

This preserves endpoint semantics (still returns stored data) while preventing active HTML/script injection in browser-rendered contexts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
